### PR TITLE
Fix Stability inpaint endpoint and improve 413 handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -242,7 +242,7 @@ def create_window_mask(image_path: str, windows: List[Dict[str, Any]]) -> Image.
 
 async def call_stability_inpaint(image_bytes: bytes, mask_png: bytes, prompt: str) -> bytes:
     """Вызов Stability API для замены окон"""
-    url = "https://i.ytimg.com/vi/N913hReVxMM/maxresdefault.jpg"
+    url = "https://api.stability.ai/v2beta/stable-image/edit/inpaint"
     headers = {"Authorization": f"Bearer {STABILITY_API_KEY}", "Accept": "image/*"}
 
     form = aiohttp.FormData()
@@ -254,6 +254,10 @@ async def call_stability_inpaint(image_bytes: bytes, mask_png: bytes, prompt: st
 
     async with aiohttp.ClientSession(timeout=REQUEST_TIMEOUT) as sess:
         async with sess.post(url, headers=headers, data=form) as resp:
+            if resp.status == 413:
+                raise RuntimeError(
+                    "Stability API вернул 413 (слишком большой запрос). Попробуйте отправить изображение меньшего размера."
+                )
             if resp.status != 200:
                 txt = await resp.text()
                 raise RuntimeError(f"Ошибка Stability API: {resp.status} {txt}")


### PR DESCRIPTION
## Summary
- point the inpaint call to the Stability API endpoint instead of the placeholder URL
- surface a clear error message when the API returns HTTP 413 for oversized uploads

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d9635d9874832bb83483e195e78e6b